### PR TITLE
【バグ修正】本番環境のトップページで画像が表示されない

### DIFF
--- a/app/views/homes/_footerMain.html.haml
+++ b/app/views/homes/_footerMain.html.haml
@@ -34,5 +34,5 @@
           = link_to 'お知らせ', "#"
 
   .footer__logo
-    = image_tag '/assets/material/logo/logo-white.png', height: '47', width: '160', class: 'img'
+    = image_tag 'material/logo/logo-white.png', height: '47', width: '160', class: 'img'
   %p © FURIMA

--- a/app/views/homes/_headerMain.html.haml
+++ b/app/views/homes/_headerMain.html.haml
@@ -2,11 +2,11 @@
   .headerBox
     .headerBox__top
       .headerBox__top__logo
-        = image_tag '/assets/material/logo/logo.png', height: '40', width: '140', class: 'img'
+        = image_tag 'material/logo/logo.png', height: '40', width: '140', class: 'img'
       .headerBox__top__searchBox
         %input.headerBox__top__searchBox__form{:name => "search", :placeholder => "キーワードから探す"}/
         .headerBox__top__searchBox__icon
-          = image_tag '/assets/material/icon/icon-search 1.png', height: '20', width: '20'
+          = image_tag 'material/icon/icon-search 1.png', height: '20', width: '20'
 
 
     .headerBox__bottom

--- a/app/views/homes/_main.html.haml
+++ b/app/views/homes/_main.html.haml
@@ -6,9 +6,9 @@
         FURIMAはだれでもかんたんに出品・購入できる<br>フリマアプリです
       .mainVisual-desc__btn
         .mainVisual-desc__btn__appleBtn
-          = link_to image_tag('/assets/material/icon/appStoreLogo.svg', height: '54', width: '180', ),"#",crass:"img"
+          = link_to image_tag('material/icon/appStoreLogo.svg', height: '54', width: '180', ),"#",crass:"img"
         .mainVisual-desc__btn__googleBtn
-          = link_to image_tag('/assets/material/icon/googlePlayLogo.svg', height: '54', width: '180', ),"#",crass:"img"
+          = link_to image_tag('material/icon/googlePlayLogo.svg', height: '54', width: '180', ),"#",crass:"img"
   
   .reason
     %h2.reason__head FURIMAが選ばれる3つの理由
@@ -16,7 +16,7 @@
       %li.reason-desc__list
         .reason-desc__image
           %span.number 1
-          = image_tag '/assets/material/pict/pict-reason-01.jpg', height: '306', width: '306', class: 'img'
+          = image_tag 'material/pict/pict-reason-01.jpg', height: '306', width: '306', class: 'img'
         %h3.reason-desc__headline
           %span.color 3分
           ですぐに出品
@@ -24,7 +24,7 @@
       %li.reason-desc__list
         .reason-desc__image
           %span.number 2
-          = image_tag '/assets/material/pict/pict-reason-02.jpg', height: '306', width: '306', class: 'img'
+          = image_tag 'material/pict/pict-reason-02.jpg', height: '306', width: '306', class: 'img'
         %h3.reason-desc__headline
           %span.color シンプル
           で使いやすい
@@ -32,7 +32,7 @@
       %li.reason-desc__list
         .reason-desc__image
           %span.number 3
-          = image_tag '/assets/material/pict/pict-reason-03.jpg', height: '306', width: '306', class: 'img'
+          = image_tag 'material/pict/pict-reason-03.jpg', height: '306', width: '306', class: 'img'
         %h3.reason-desc__headline
           手数料
           %span.color 業界最安
@@ -48,28 +48,28 @@
         ほしかったあの商品に出会えるかもしれません。<br>
       .middleBanner-desc__btn
         .middleBanner-desc__btn__appleBtn
-        = link_to image_tag('/assets/material/icon/appStoreLogo.svg', height: '54', width: '180', ),"#",crass:"img"
+        = link_to image_tag('material/icon/appStoreLogo.svg', height: '54', width: '180', ),"#",crass:"img"
         .middleBanner-desc__btn__googleBtn
-        = link_to image_tag('/assets/material/icon/googlePlayLogo.svg', height: '54', width: '180', ),"#",crass:"img"
+        = link_to image_tag('material/icon/googlePlayLogo.svg', height: '54', width: '180', ),"#",crass:"img"
 
   .feature
     %h2.feature__head FURIMAの特徴
     %ul.feature-desc
       %li.feature-desc__list
         .feature-desc__image
-          = image_tag '/assets/material/icon/icon-01.png', width: '200', class: 'img'
+          = image_tag 'material/icon/icon-01.png', width: '200', class: 'img'
         %h3.feature-desc__headline
           簡単に売り買いできる
         .feature-desc__text スマホひとつで、いつでもどこでも簡単に出品・購入が可能！
       %li.feature-desc__list
         .feature-desc__image
-          = image_tag '/assets/material/icon/icon-03.png', width: '200', class: 'img'
+          = image_tag 'material/icon/icon-03.png', width: '200', class: 'img'
         %h3.feature-desc__headline
           売上金は即日振込みに対応
         .feature-desc__text 午前9時までに振込を依頼いただければ、翌日に指定の口座に入金いたします!
       %li.feature-desc__list
         .feature-desc__image
-          = image_tag '/assets/material/icon/icon-04.png', width: '200', class: 'img'
+          = image_tag 'material/icon/icon-04.png', width: '200', class: 'img'
         %h3.feature-desc__headline
           様々な支払いに対応
         .feature-desc__text お支払いは、クレジットカードだけでなく、ポイントや売上金など多彩な方法があります。
@@ -82,7 +82,7 @@
         = link_to "#" do
           .containerBox-list
             .containerBox-list__image
-              = image_tag '/assets/material/pict/a001.png', class: 'img'
+              = image_tag 'material/pict/a001.png', class: 'img'
             .containerBox-list__detail
               %h3.name product1
               %ul.desc
@@ -93,7 +93,7 @@
         = link_to "#" do
           .containerBox-list
             .containerBox-list__image
-              = image_tag '/assets/material/pict/a004.png', class: 'img'
+              = image_tag 'material/pict/a004.png', class: 'img'
             .containerBox-list__detail
               %h3.name product2
               %ul.desc
@@ -104,7 +104,7 @@
         = link_to "#" do
           .containerBox-list
             .containerBox-list__image
-              = image_tag '/assets/material/pict/a007.png', class: 'img'
+              = image_tag 'material/pict/a007.png', class: 'img'
             .containerBox-list__detail
               %h3.name product3
               %ul.desc
@@ -120,6 +120,6 @@
       .bottomBanner-desc__text 今すぐ無料ダウンロード！
       .bottomBanner-desc__btn
         .bottomBanner-desc__btn__appleBtn
-        = link_to image_tag('/assets/material/icon/appStoreLogo.svg', height: '54', width: '180', ),"#",crass:"img"
+        = link_to image_tag('material/icon/appStoreLogo.svg', height: '54', width: '180', ),"#",crass:"img"
         .bottomBanner-desc__btn__googleBtn
-        = link_to image_tag('/assets/material/icon/googlePlayLogo.svg', height: '54', width: '180', ),"#",crass:"img"
+        = link_to image_tag('material/icon/googlePlayLogo.svg', height: '54', width: '180', ),"#",crass:"img"

--- a/app/views/homes/_sellBtn.html.haml
+++ b/app/views/homes/_sellBtn.html.haml
@@ -3,4 +3,4 @@
   .sellBtn
     出品する
     .sellBtn--image
-    = image_tag '/assets/material/icon/icon_camera.png',height: '54', width: '54', class: 'btn'
+    = image_tag 'material/icon/icon_camera.png',height: '54', width: '54', class: 'btn'


### PR DESCRIPTION
## 概要
本番環境のトップページ画面にて、
image_tagメソッドで指定された画像が表示されないため、修正を行います。

## 修正箇所
トップページ用のhamlファイル

## 修正内容
image_tagメソッドで指定している各パスの開始部分を、/assetsではなくmaterialsディレクトリに変更します。