### PR TITLE
マイページとマイページログアウト画面のヘッダー・フッター追加

### DIFF
--- a/app/assets/stylesheets/modules/user/_logout.scss
+++ b/app/assets/stylesheets/modules/user/_logout.scss
@@ -1,7 +1,7 @@
 .mypageLogout {
   width: 100vw;
   height: 270px;
-  margin: 30px 100px 30px 0;
+  margin: 30px 0;
   padding: 80px;
   background-color: white;
   text-align: center;
@@ -11,5 +11,8 @@
       color: white;
       line-height: 50px
     }
+  }
+  &__title:hover {
+    opacity: 0.8;
   }
 }

--- a/app/assets/stylesheets/modules/user/_mypage_main.scss
+++ b/app/assets/stylesheets/modules/user/_mypage_main.scss
@@ -1,5 +1,5 @@
 .mypage__main {
-  margin: 30px 100px 30px 0;
+  margin: 30px 0;
   width: 100vw;
   &__top {
     background-color: white;

--- a/app/assets/stylesheets/modules/user/_mypage_sidebar.scss
+++ b/app/assets/stylesheets/modules/user/_mypage_sidebar.scss
@@ -1,10 +1,19 @@
-.mypage {
+.mainbox{
+  padding: 0 60px;
   background-color: #eeeeee;
+}
+.mypage {
   display: flex;
+  max-width: 1040px;
+  width: 100%;
+  min-height: 82px;
+  margin: 0 auto;
+  padding: 15px 0 0;
+  
 }
 .mypage__sidebar {
-  // background-color: white;
-  margin: 30px 30px 30px 100px;
+  padding: 30px 30px 30px 0;
+  margin: 0 auto;
   font-size: 14px;
   &__box {
     background-color: white;

--- a/app/views/homes/_headerMain.html.haml
+++ b/app/views/homes/_headerMain.html.haml
@@ -2,7 +2,8 @@
   .headerBox
     .headerBox__top
       .headerBox__top__logo
-        = image_tag 'material/logo/logo.png', height: '40', width: '140', class: 'img'
+        = link_to root_path do
+          = image_tag 'material/logo/logo.png', height: '40', width: '140', class: 'img'
       .headerBox__top__searchBox
         %input.headerBox__top__searchBox__form{:name => "search", :placeholder => "キーワードから探す"}/
         .headerBox__top__searchBox__icon

--- a/app/views/homes/index.html.haml
+++ b/app/views/homes/index.html.haml
@@ -3,4 +3,3 @@
   = render 'main'
   = render 'footerMain'
   = render 'sellBtn'
-

--- a/app/views/users/logout.html.haml
+++ b/app/views/users/logout.html.haml
@@ -1,7 +1,10 @@
-.mypage
-  = render "users/mypage_sidebar"
-  .mypageLogout
-    .mypageLogout__title
-      = link_to destroy_user_session_path, method: :delete do
-        .mypageLogout__title--button
-          ログアウト
+= render 'homes/headerMain'
+.mainbox
+  .mypage
+    = render "users/mypage_sidebar"
+    .mypageLogout
+      .mypageLogout__title
+        = link_to destroy_user_session_path, method: :delete do
+          .mypageLogout__title--button
+            ログアウト
+= render 'homes/footerMain'

--- a/app/views/users/logout.html.haml
+++ b/app/views/users/logout.html.haml
@@ -8,3 +8,4 @@
           .mypageLogout__title--button
             ログアウト
 = render 'homes/footerMain'
+= render 'homes/sellBtn'

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -1,5 +1,7 @@
-.mypage
-  -# = render 'headerMain'
-  = render "users/mypage_sidebar"
-  = render "users/mypage_main"
-  -# = render 'footerMain'
+= render 'homes/headerMain'
+.mainbox
+  .mypage
+    = render "users/mypage_sidebar"
+    = render "users/mypage_main"
+= render 'homes/footerMain'
+= render 'homes/sellBtn'


### PR DESCRIPTION
## what
- マイページ及びログアウト画面のヘッダー・フッターにトップページのヘッダー・フッターと同様のものを追加
- マイページに出品ボタン追加
- ヘッダー・フッター追加に伴う配置等の微調整
- ヘッダーのロゴからトップページへ飛ぶlink_to実装

## why
- マイページにもヘッダー・フッターを表示させるため
- どこからでも出品しやすいようにするため
- マイページからトップページに遷移できるようにするため

### マイページ・ログアウトページ↓
https://gyazo.com/1403d4af67bceeb927d3df6e87588c2f