### PR TITLE
商品購入履歴のテーブルを作成

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@
 - belongs_to :sns_credential dependent: :destroy
 - has_one :credit_card dependent: :destroy
 - has_one :shipping_address dependent: :destroy
+- has_many :histories
 
 
 ## items_table
@@ -57,7 +58,7 @@
 - belongs_to :prefectures
 - belongs_to :user
 - belongs_to :rating dependent: :destroy
-
+- has_one :history
 
 ## shipping_address_table
 
@@ -163,3 +164,14 @@
 ### Association
 - has_many : items
 - has_ancestry
+
+## history_table
+|Column|Type|Options|
+|------|----|-------|
+|ID|integer|null:false|
+|user_id|integer|foreign_key:true, null:false|
+|item_id|integer|foreign_key:true, null:false|
+
+### association
+- belongs_to :item
+- belongs_to :user

--- a/app/models/history.rb
+++ b/app/models/history.rb
@@ -1,0 +1,4 @@
+class History < ApplicationRecord
+  belongs_to :user
+  belongs_to :item
+end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -7,4 +7,5 @@ class Item < ApplicationRecord
   belongs_to :prefecture
   belongs_to :user
   belongs_to :rating, dependent: :destroy
+  has_one    :history
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -9,4 +9,5 @@ class User < ApplicationRecord
   validates :name_first, :name_last, format: { with: /\A[ぁ-んァ-ン一-龥]/, message: "全角で入力してください" }
   validates :name_first_kana, :name_last_kana, format: { with: /\A[\p{katakana}　ー－&&[^ -~｡-ﾟ]]+\z/, message: "全角カタカナで入力してください" }
   has_one :shipping_address, dependent: :destroy
+  has_many :histories
 end

--- a/db/migrate/20200425085547_create_histories.rb
+++ b/db/migrate/20200425085547_create_histories.rb
@@ -1,0 +1,10 @@
+class CreateHistories < ActiveRecord::Migration[5.2]
+  def change
+    create_table :histories do |t|
+      t.references :user, foreign_key: true, null: false
+      t.references :item, foreign_key: true, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -26,6 +26,15 @@ ActiveRecord::Schema.define(version: 2020_04_29_053829) do
     t.index ["ancestry"], name: "index_categories_on_ancestry"
   end
 
+  create_table "histories", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.bigint "user_id", null: false
+    t.bigint "item_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["item_id"], name: "index_histories_on_item_id"
+    t.index ["user_id"], name: "index_histories_on_user_id"
+  end
+
   create_table "item_images", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.bigint "item_id", null: false
     t.text "image_URL", null: false
@@ -92,6 +101,8 @@ ActiveRecord::Schema.define(version: 2020_04_29_053829) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "histories", "items"
+  add_foreign_key "histories", "users"
   add_foreign_key "item_images", "items"
   add_foreign_key "shipping_addresses", "users"
 end


### PR DESCRIPTION
## what
商品購入履歴のテーブルの作成およびそのモデルの実装を行います。
また、README.rmにこのテーブルの設計とアソシエーションの記述を行います。

## why
売り切れた商品を商品一覧に並ばない・買えないようにする実装に用いるため。
ユーザーが自分の売り上げを確認できるようにするため。
ユーザーが自分の商品購入履歴を確認できるようにするため。