### PR TITLE
ログイン画面・新規登録画面のヘッダー・フッターの切り出し

### DIFF
--- a/app/assets/stylesheets/modules/user/_header_footer.scss
+++ b/app/assets/stylesheets/modules/user/_header_footer.scss
@@ -1,12 +1,34 @@
 .header {
   background-color: #eeeeee;
+  height: 128px;
+  text-align: center;
+
   &__image {
-    margin: 0 auto;
-    max-width: 50%;
-    text-align: center;
+    padding-top: 40px;
   }
 }
 .footer {
   background-color: #eeeeee;
-  height: 50px;
+  text-align: center;
+  height: 220px;
+  padding: 40px 0;
+
+  &__menu {
+
+    &__list {
+      color: black;
+      text-decoration: none;
+      font-size: 12px;
+      margin-right: 16px;
+    }
+  }
+
+  &__logo {
+    margin: 40px auto 0;
+  }
+
+  &__copyright {
+    font-size: 13px;
+    margin: 8px 0 0;
+  }
 }

--- a/app/assets/stylesheets/modules/user/_header_footer.scss
+++ b/app/assets/stylesheets/modules/user/_header_footer.scss
@@ -32,3 +32,9 @@
     margin: 8px 0 0;
   }
 }
+
+.footerMargin {
+  background-color: #eeeeee;
+  height: 180px;
+  width: 100%;
+}

--- a/app/views/devise/registrations/complete_user.haml
+++ b/app/views/devise/registrations/complete_user.haml
@@ -1,6 +1,5 @@
-.header
-  .header__image
-    = image_tag 'material/logo/logo.png', size: "185x49"
+= render "shared/single_header"
+
 .userCreate
   = render "devise/registrations/complete_header"
   .userCreate__usercomp
@@ -14,4 +13,5 @@
         = link_to root_path do
           .userCreate__usercomp__body__start--button
             フリマをはじめる
-.footer
+
+= render "shared/single_footer"

--- a/app/views/devise/registrations/new.html.haml
+++ b/app/views/devise/registrations/new.html.haml
@@ -1,6 +1,5 @@
-.header
-  .header__image
-    = image_tag 'material/logo/logo.png', size: "185x49"
+= render "shared/single_header"
+
 .userCreate
   = render "devise/registrations/user_create_header"
   .userCreate__userinfo
@@ -60,4 +59,5 @@
         .userCreate__userinfo__body__formbox
           .userCreate__userinfo__body__formbox__next--button
             = f.submit "次へ進む"
-.footer
+
+= render "shared/single_footer"

--- a/app/views/devise/registrations/new_shipping_address.html.haml
+++ b/app/views/devise/registrations/new_shipping_address.html.haml
@@ -1,6 +1,5 @@
-.header
-  .header__image
-    = image_tag 'material/logo/logo.png', size: "185x49"
+= render "shared/single_header"
+
 .userCreate
   = render "devise/registrations/shipping_header"
   .userCreate__userinfo
@@ -66,4 +65,5 @@
         .userCreate__userinfo__body__formbox
           .userCreate__userinfo__body__formbox__next--button
             = f.submit "確認"
-.footer
+
+= render "shared/single_footer"

--- a/app/views/devise/sessions/new.html.haml
+++ b/app/views/devise/sessions/new.html.haml
@@ -1,6 +1,5 @@
-.header
-  .header__image
-    = image_tag 'material/logo/logo.png', size: "185x49"
+= render "shared/single_header"
+
 .userLogin
   .userLogin__userCreate
     .userLogin__userCreate__title
@@ -22,4 +21,5 @@
           = f.password_field :password, placeholder: 'パスワード', pattern: ".{7,}"
         .userLogin__main__loginbox__login--button
           = f.submit "ログイン"
-.footer
+
+= render "shared/single_footer"

--- a/app/views/shared/_single_footer.html.haml
+++ b/app/views/shared/_single_footer.html.haml
@@ -1,0 +1,13 @@
+//ユーザー登録画面や、商品購入確認画面のフッター
+.footer
+  .footer__menu
+    = link_to "プライバシーポリシー", "#", class: "footer__menu__list"
+    = link_to "FURIMA利用規約", "#", class: "footer__menu__list"
+    = link_to "特定商取引に関する表記", "#", class: "footer__menu__list"
+
+  .footer__logo
+    = link_to root_path do
+      = image_tag 'material/logo/logo-white.png', size: "185x49"
+
+  .footer__copyright
+    © FURIMA

--- a/app/views/shared/_single_header.html.haml
+++ b/app/views/shared/_single_header.html.haml
@@ -1,0 +1,5 @@
+//ユーザー登録画面や、商品購入確認画面のヘッダー
+.header
+  .header__image
+    = link_to root_path do
+      = image_tag 'material/logo/logo.png', size: "185x49"

--- a/app/views/users/index.html.haml
+++ b/app/views/users/index.html.haml
@@ -12,4 +12,6 @@
             %span<>
             メールアドレスで登録
 
+-# 画面下部に余白がでないようにする
+.footerMargin
 = render "shared/single_footer"

--- a/app/views/users/index.html.haml
+++ b/app/views/users/index.html.haml
@@ -1,6 +1,5 @@
-.header
-  .header__image
-    = image_tag 'material/logo/logo.png', size: "185x49"
+= render "shared/single_header"
+
 .userCreate
   .userCreate__index
     .userCreate__index__title
@@ -12,4 +11,5 @@
             = icon('far', 'envelope', class: "userCreate__index__pattern__mail--icon")
             %span<>
             メールアドレスで登録
-.footer
+
+= render "shared/single_footer"


### PR DESCRIPTION
## what
ログイン画面・新規登録画面のヘッダー・フッター部分を共通化します
また、同時に以下２点の修正を行います。
・ヘッダーロゴ・フッターロゴにトップ画面へ遷移できるリンクを設置します。
・新規登録方法選択画面下部に余白でないようにする

## why
商品購入確認画面でも使いまわせるようにするため。



