### PR TITLE
ユーザ登録フォームのエラーメッセージ表示方法の修正

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -15,6 +15,7 @@
 @import "modules/user/user_create";
 @import "modules/user/complete_user";
 @import "modules/user/user_login";
+@import "modules/user/error_messages";
 @import "modules/flash";
 
 @import "modules/user/mypage_sidebar";

--- a/app/assets/stylesheets/mixin/user_create.scss
+++ b/app/assets/stylesheets/mixin/user_create.scss
@@ -7,7 +7,7 @@
 @mixin user_input_box {
   width: 700px;
   background-color: white;
-  margin: auto;
+  margin: 0 auto;
   padding: 30px 0;
 }
 
@@ -28,8 +28,9 @@
 }
 
 @mixin user_form_box {
-  margin: auto;
-  padding: 20px 200px;
+  margin: 0 auto;
+  padding: 10px auto;
+  width: 300px;
   font-size: 14px;
 }
 
@@ -98,4 +99,12 @@
   margin: 5px;
   background-color: #cccccc;
   border: 1px solid #3CCACE;
+}
+
+@mixin flash_message {
+  margin: 0 auto;
+  padding: 10px;
+  font-size: 14px;
+  text-align: center;
+  color: white;
 }

--- a/app/assets/stylesheets/modules/flash.scss
+++ b/app/assets/stylesheets/modules/flash.scss
@@ -1,13 +1,14 @@
 .notice {
-  color: #FFCC33;
-  text-align: center;
+  @include flash_message;
+  background-color: #3CCACE;
 }
 
 .alert {
-  color: #FF3300;
-  text-align: center;
+  @include flash_message;
+  background-color: #FF0000;
 }
 
 #error_explanation {
-  color: #FF3300;
+  @include flash_message;
+  background-color: #FF0000;
 }

--- a/app/assets/stylesheets/modules/user/_error_messages.scss
+++ b/app/assets/stylesheets/modules/user/_error_messages.scss
@@ -1,0 +1,21 @@
+#shipping_address_prefecture_id {
+  display: flex;
+}
+.error {
+  input, select {
+    border-color: #FF0000;
+  }
+}
+.has_error {
+  color: #FF0000;
+  font-size: 12px;
+  line-height: 24px;
+  text-align: left;
+  white-space: nowrap
+}
+
+#name_first_kana_error, #name_first_error {
+  position: absolute;
+  left: 0;
+  top: 70px;
+}

--- a/app/assets/stylesheets/modules/user/_user_create.scss
+++ b/app/assets/stylesheets/modules/user/_user_create.scss
@@ -4,8 +4,9 @@
     @include user_title;
   }
   &__body {
+    @include user_form_box;
     &__formbox {
-      @include user_form_box;
+      padding: 20px 0;
       &__title {
         text-align: left;
         padding-bottom: 4px;
@@ -25,19 +26,29 @@
         margin-bottom: 10px;
         @include form_box;
         select {
-          width: 80px;
+          width: 86px;
           height: 50px;
-        }
-        &__harfword {
-          padding-right: 20px;
-          input {
-            width: 140px;
-          }
         }
         input[type="number"]::-webkit-outer-spin-button,
         input[type="number"]::-webkit-inner-spin-button {
           -webkit-appearance: none;
           margin: 0;
+        }
+      }
+      &__harfform {
+        display: inline-flex;
+        line-height: 50px;
+        margin-bottom: 10px;
+        position: relative;
+        &__harfword {
+          width: 150px;
+          padding-right: 20px;
+          input {
+            width: 140px;
+            height: 50px;
+            border-radius: 5px;
+            border: 1px solid #bbbbbb;
+          }
         }
       }
       &__next--button {
@@ -46,6 +57,9 @@
           color: white;
           cursor: pointer;
         }
+      }
+      &__personaltitle {
+        font-size: 18px;
       }
     }
   }

--- a/app/assets/stylesheets/modules/user/_user_login.scss
+++ b/app/assets/stylesheets/modules/user/_user_login.scss
@@ -20,7 +20,8 @@
     @include user_input_box;
     &__loginbox {
       &__title {
-        font-size: 14px;
+        padding: 10px;
+        font-size: 16px;
       }
       &__form {
         padding: 10px 0;

--- a/app/views/devise/registrations/new.html.haml
+++ b/app/views/devise/registrations/new.html.haml
@@ -8,19 +8,21 @@
       会員情報入力
     .userCreate__userinfo__body
       = form_for(@user, url: registration_path(resource_name)) do |f|
-        = devise_error_messages!
+
         .userCreate__userinfo__body__formbox
           .userCreate__userinfo__body__formbox__title
             = f.label :nickname, "ニックネーム"
             %span 必須
           .userCreate__userinfo__body__formbox__form
             = f.text_field :nickname, placeholder: '例）ふりまり子'
+
         .userCreate__userinfo__body__formbox
           .userCreate__userinfo__body__formbox__title
             = f.label :email, "メール"
             %span 必須
           .userCreate__userinfo__body__formbox__form
             = f.email_field :email, placeholder: 'PC・携帯どちらでも可'
+
         .userCreate__userinfo__body__formbox
           .userCreate__userinfo__body__formbox__title
             = f.label :password, "パスワード"
@@ -31,32 +33,36 @@
             = f.label :password_confirmation, "パスワード再入力"
           .userCreate__userinfo__body__formbox__form
             = f.password_field :password_confirmation, placeholder: '7文字以上の半角英数字', autocomplete: "off"
+
         .userCreate__userinfo__body__formbox__personaltitle
-          %h3 本人確認
+          本人確認
         .userCreate__userinfo__body__formbox
           .userCreate__userinfo__body__formbox__title
             = f.label :name, "お名前(全角)"
             %span 必須
-          .userCreate__userinfo__body__formbox__form
-            .userCreate__userinfo__body__formbox__form__harfword
+          .userCreate__userinfo__body__formbox__harfform
+            .userCreate__userinfo__body__formbox__harfform__harfword
               = f.text_field :name_last, placeholder: '例）田中'
-            .userCreate__userinfo__body__formbox__form__harfword
+            .userCreate__userinfo__body__formbox__harfform__harfword
               = f.text_field :name_first, placeholder: '例）太郎'
+
         .userCreate__userinfo__body__formbox
           .userCreate__userinfo__body__formbox__title
             = f.label :name_kana, "フリガナ(全角カナ)"
             %span 必須
-          .userCreate__userinfo__body__formbox__form
-            .userCreate__userinfo__body__formbox__form__harfword
+          .userCreate__userinfo__body__formbox__harfform
+            .userCreate__userinfo__body__formbox__harfform__harfword
               = f.text_field :name_last_kana, placeholder: '例）タナカ'
-            .userCreate__userinfo__body__formbox__form__harfword
+            .userCreate__userinfo__body__formbox__harfform__harfword
               = f.text_field :name_first_kana, placeholder: '例）タロウ'
+
         .userCreate__userinfo__body__formbox
           .userCreate__userinfo__body__formbox__title
             = f.label :birth, "生年月日"
             %span 必須
           .userCreate__userinfo__body__formbox__form
-            != sprintf(f.date_select(:birth, prompt: "---", with_css_classes:'birth', use_month_numbers: true,start_year: (Time.now.year), end_year: (Time.now.year - 100), date_separator: '%s'),'年','月')+'日'
+            = f.date_select(:birth, prompt: "---", with_css_classes:'birth', use_month_numbers: true,start_year: (Time.now.year), end_year: (Time.now.year - 100), date_separator: '／')
+
         .userCreate__userinfo__body__formbox
           .userCreate__userinfo__body__formbox__next--button
             = f.submit "次へ進む"

--- a/app/views/devise/registrations/new_shipping_address.html.haml
+++ b/app/views/devise/registrations/new_shipping_address.html.haml
@@ -8,61 +8,69 @@
       送付先情報
     .userCreate__userinfo__body
       = form_for(@shipping_address) do |f|
-        = devise_error_messages!
+
         .userCreate__userinfo__body__formbox
           .userCreate__userinfo__body__formbox__title
             = f.label :name, "送付先氏名(全角)"
             %span 必須
-          .userCreate__userinfo__body__formbox__form
-            .userCreate__userinfo__body__formbox__form__harfword
+          .userCreate__userinfo__body__formbox__harfform
+            .userCreate__userinfo__body__formbox__harfform__harfword
               = f.text_field :name_last, placeholder: '例）田中'
-            .userCreate__userinfo__body__formbox__form__harfword
+            .userCreate__userinfo__body__formbox__harfform__harfword
               = f.text_field :name_first, placeholder: '例）太郎'
+
         .userCreate__userinfo__body__formbox
           .userCreate__userinfo__body__formbox__title
             = f.label :name_kana, "フリガナ(全角カナ)"
             %span 必須
-          .userCreate__userinfo__body__formbox__form
-            .userCreate__userinfo__body__formbox__form__harfword
+          .userCreate__userinfo__body__formbox__harfform
+            .userCreate__userinfo__body__formbox__harfform__harfword
               = f.text_field :name_last_kana, placeholder: '例）タナカ'
-            .userCreate__userinfo__body__formbox__form__harfword
+            .userCreate__userinfo__body__formbox__harfform__harfword
               = f.text_field :name_first_kana, placeholder: '例）タロウ'
+
         .userCreate__userinfo__body__formbox
           .userCreate__userinfo__body__formbox__title
             = f.label :zipcode, "〒郵便番号（ハイフンなし）"
             %span 必須
           .userCreate__userinfo__body__formbox__form
             = f.number_field :zipcode, placeholder: '例）1234567', pattern: "\d{7}"
+
         .userCreate__userinfo__body__formbox
           .userCreate__userinfo__body__formbox__title
             = f.label :prefecture_id, "都道府県"
             %span 必須
           .userCreate__userinfo__body__formbox__form
-            = f.collection_select :prefecture_id, Prefecture.all, :id, :name
+            = f.collection_select :prefecture_id, Prefecture.all, :id, :name, prompt: "---"
+
         .userCreate__userinfo__body__formbox
           .userCreate__userinfo__body__formbox__title
             = f.label :city, "市区町村"
             %span 必須
           .userCreate__userinfo__body__formbox__form
             = f.text_field :city, placeholder: '例）横浜市葵区'
+
         .userCreate__userinfo__body__formbox
           .userCreate__userinfo__body__formbox__title
             = f.label :street_address, "番地"
             %span 必須
           .userCreate__userinfo__body__formbox__form
             = f.text_field :street_address, placeholder: '例）青山1-1-1'
+
         .userCreate__userinfo__body__formbox
           .userCreate__userinfo__body__formbox__title
             = f.label :building, "建物"
             %span.any 任意
           .userCreate__userinfo__body__formbox__form
             = f.text_field :building, placeholder: '例）フォンティスビルディング11F'
+
         .userCreate__userinfo__body__formbox
           .userCreate__userinfo__body__formbox__title
             = f.label :phone_number, "電話番号(ハイフンなし)"
             %span.any 任意
           .userCreate__userinfo__body__formbox__form
             = f.number_field :phone_number, placeholder: '例）09012341234', pattern: "\d{10,11}"
+
         .userCreate__userinfo__body__formbox
           .userCreate__userinfo__body__formbox__next--button
             = f.submit "確認"

--- a/config/application.rb
+++ b/config/application.rb
@@ -21,5 +21,23 @@ module FreemarketSampleA67
     # -- all .rb files in that directory are automatically loaded after loading
     # the framework and any gems in your application.
     config.i18n.default_locale = :ja
+    config.action_view.field_error_proc = Proc.new do |html_tag, instance|
+      if instance.kind_of?(ActionView::Helpers::Tags::Label)
+        html_tag.html_safe
+      else
+        method_name = instance.instance_variable_get(:@method_name)
+        errors = instance.object.errors[method_name]
+
+        html = <<~EOM
+          <div class=error>#{html_tag}
+            <div class="has_error" id="#{method_name}_error">
+              #{I18n.t("activerecord.attributes.#{instance.object.class.name.underscore}.#{method_name}")}
+              #{errors.first}
+            </div>
+          </div>
+        EOM
+        html.html_safe
+      end
+    end
   end
 end

--- a/config/locales/models.ja.yml
+++ b/config/locales/models.ja.yml
@@ -7,16 +7,16 @@ ja:
         password_confirmation: 確認用パスワード
         remember_me: 次回から自動的にログイン
         nickname: ニックネーム
-        name_first: 苗字
-        name_last: 名前
-        name_first_kana: 苗字カナ
-        name_last_kana: 名前カナ
+        name_first: 名
+        name_last: 姓
+        name_first_kana: 名カナ
+        name_last_kana: 姓カナ
         birth: 生年月日
       shipping_address:
-        name_first: 苗字
-        name_last: 名前
-        name_first_kana: 苗字カナ
-        name_last_kana: 名前カナ
+        name_first: 名
+        name_last: 姓
+        name_first_kana: 名カナ
+        name_last_kana: 姓カナ
         zipcode: 郵便番号
         prefecture_id: 都道府県
         city: 市区町村


### PR DESCRIPTION
## what
### ユーザ新規登録時、ログイン時のエラーハンドリング
- ログイン画面：フラッシュメッセージで表示
- 新規登録画面：各フォーム下にエラーがでるように実装
- 上記に伴う見た目の調整

## why
- フォーム入力時のエラーがどこなのかユーザにとって見やすい形にするため

ログイン画面
https://gyazo.com/5bda5d8ca5e6cc758de789b32261790b

1枚目
https://gyazo.com/0ceb91454efa991a1991193cadb07ce6

２枚目
https://gyazo.com/dd4cd95a0ed08da16b2b073801943b28