### PR TITLE
マイページ画面から遷移するメール・パスワード変更画面の実装

### DIFF
--- a/app/assets/stylesheets/mixin/user_create.scss
+++ b/app/assets/stylesheets/mixin/user_create.scss
@@ -8,14 +8,14 @@
   width: 700px;
   background-color: white;
   margin: 0 auto;
-  padding: 30px 0;
 }
 
 @mixin user_title {
-  padding: 0 0 30px 0;
+  padding: 30px 0;
   border-bottom: 1px solid #eeeeee;
   font-size: 22px;
   font-weight: bold;
+  text-align: center;
 }
 
 @mixin user_button {

--- a/app/assets/stylesheets/modules/user/_user_login.scss
+++ b/app/assets/stylesheets/modules/user/_user_login.scss
@@ -3,7 +3,7 @@
   &__userCreate {
     @include user_input_box;
     border-bottom: 1px solid #eeeeee;
-    padding-bottom: 20px;
+    padding-top: 30px;
     &__title {
       font-size: 14px;
     }

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -44,7 +44,7 @@ class Users::RegistrationsController < Devise::RegistrationsController
   end
 
   def after_update_path_for(resource)
-    "/users/#{current_user.id}"
+    edit_user_registration_path
   end
 
   # GET /resource/edit

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -43,6 +43,10 @@ class Users::RegistrationsController < Devise::RegistrationsController
     end
   end
 
+  def after_update_path_for(resource)
+    "/users/#{current_user.id}"
+  end
+
   # GET /resource/edit
   # def edit
   #   super
@@ -97,4 +101,5 @@ class Users::RegistrationsController < Devise::RegistrationsController
   def shipping_address_params
     params.require(:shipping_address).permit(:name_first, :name_last, :name_first_kana, :name_last_kana, :zipcode, :prefecture_id, :city, :street_address, :building, :phone_number)
   end
+
 end

--- a/app/views/devise/registrations/edit.html.haml
+++ b/app/views/devise/registrations/edit.html.haml
@@ -1,36 +1,38 @@
-%h2
-  Edit #{resource_name.to_s.humanize}
-= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f|
-  = render "devise/shared/error_messages", resource: resource
-  .field
-    = f.label :email
-    %br/
-    = f.email_field :email, autofocus: true, autocomplete: "email"
-  - if devise_mapping.confirmable? && resource.pending_reconfirmation?
-    %div
-      Currently waiting confirmation for: #{resource.unconfirmed_email}
-  .field
-    = f.label :password
-    %i (leave blank if you don't want to change it)
-    %br/
-    = f.password_field :password, autocomplete: "new-password"
-    - if @minimum_password_length
-      %br/
-      %em
-        = @minimum_password_length
-        characters minimum
-  .field
-    = f.label :password_confirmation
-    %br/
-    = f.password_field :password_confirmation, autocomplete: "new-password"
-  .field
-    = f.label :current_password
-    %i (we need your current password to confirm your changes)
-    %br/
-    = f.password_field :current_password, autocomplete: "current-password"
-  .actions
-    = f.submit "Update"
-%h3 Cancel my account
-%p
-  Unhappy? #{button_to "Cancel my account", registration_path(resource_name), data: { confirm: "Are you sure?" }, method: :delete}
-= link_to "Back", :back
+= render 'homes/headerMain'
+.mainbox
+  .mypage
+    = render "users/mypage_sidebar"
+    .mypage__main
+      .mypage__main__top
+        .userCreate__userinfo__title
+          メール・パスワード変更
+        .userCreate__userinfo__body
+          = form_for(@user, url: registration_path(resource_name)) do |f|
+
+            .userCreate__userinfo__body__formbox
+              .userCreate__userinfo__body__formbox__title
+                = f.label :email, "メール"
+              .userCreate__userinfo__body__formbox__form
+                = f.email_field :email, placeholder: 'PC・携帯どちらでも可'
+
+            .userCreate__userinfo__body__formbox
+              .userCreate__userinfo__body__formbox__title
+                = f.label :current_password, "現在のパスワード"
+              .userCreate__userinfo__body__formbox__form
+                = f.password_field :current_password, placeholder: '7文字以上の半角英数字', autocomplete: "off"
+              %br
+              .userCreate__userinfo__body__formbox__title
+                = f.label :password, "新しいパスワード"
+              .userCreate__userinfo__body__formbox__form
+                = f.password_field :password, placeholder: '7文字以上の半角英数字', autocomplete: "off"
+
+              .userCreate__userinfo__body__formbox__title
+                = f.label :password_confirmation, "新しいパスワード再入力"
+              .userCreate__userinfo__body__formbox__form
+                = f.password_field :password_confirmation, placeholder: '7文字以上の半角英数字', autocomplete: "off"
+
+            .userCreate__userinfo__body__formbox
+              .userCreate__userinfo__body__formbox__next--button
+                = f.submit "変更する"
+
+= render 'homes/footerMain'

--- a/app/views/devise/registrations/edit.html.haml
+++ b/app/views/devise/registrations/edit.html.haml
@@ -4,6 +4,8 @@
     = render "users/mypage_sidebar"
     .mypage__main
       .mypage__main__top
+        - flash.each do |key, value|
+          = content_tag :div, value, class: key
         .userCreate__userinfo__title
           メール・パスワード変更
         .userCreate__userinfo__body

--- a/app/views/users/_mypage_sidebar.html.haml
+++ b/app/views/users/_mypage_sidebar.html.haml
@@ -32,7 +32,7 @@
     %h4.mypage__sidebar__box__title 設定
     %ul.mypage__sidebar__box__list
       %li.mypage__sidebar__box__list__item#profile
-        = link_to "#" do
+        = link_to "" do
           プロフィール
           = icon('fa', 'chevron-right')
       %li.mypage__sidebar__box__list__item#shipping
@@ -40,7 +40,7 @@
           送付先変更
           = icon('fa', 'chevron-right')
       %li.mypage__sidebar__box__list__item#MailPassword
-        = link_to "#" do
+        = link_to edit_user_registration_path do
           メール・パスワード変更
           = icon('fa', 'chevron-right')
       %li.mypage__sidebar__box__list__item#creditcard


### PR DESCRIPTION
## what
- deviseを使用してメールアドレス、パスワード編集画面の実装
- 更新後マイページトップにリダイレクトするように実装
- 編集画面のviewの調整

## why
- ユーザ登録した後、メールアドレス、パスワードを変更できるようにするため

見た目↓
https://gyazo.com/33ee291aca95be75fb568b820910f10d