### PR TITLE
メールパスワード編集画面更新後の画面遷移修正

### DIFF
--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -44,7 +44,7 @@ class Users::RegistrationsController < Devise::RegistrationsController
   end
 
   def after_update_path_for(resource)
-    edit_user_registration_path
+    update_complete_user_path(current_user.id)
   end
 
   # GET /resource/edit

--- a/app/views/devise/registrations/edit.html.haml
+++ b/app/views/devise/registrations/edit.html.haml
@@ -1,11 +1,10 @@
+-# マイページ-メール＆パスワード編集画面
 = render 'homes/headerMain'
 .mainbox
   .mypage
     = render "users/mypage_sidebar"
     .mypage__main
       .mypage__main__top
-        - flash.each do |key, value|
-          = content_tag :div, value, class: key
         .userCreate__userinfo__title
           メール・パスワード変更
         .userCreate__userinfo__body


### PR DESCRIPTION
## what
メールパスワード編集画面で情報更新後、更新完了画面を追加
更新完了画面は以前実装したプロフィール編集後の更新完了画面と同じもの
## why
更新完了がユーザにとってわかりやすいようにするため