### PR TITLE
トップの商品一覧と売り切れ表示の実装

### DIFF
--- a/app/assets/stylesheets/modules/home/_index.scss
+++ b/app/assets/stylesheets/modules/home/_index.scss
@@ -319,6 +319,26 @@
         width: 220px;
         display: inline-block;
         float: left;
+        position: relative;
+        .containerBox-list__sold{
+          position: absolute;
+          width: 0;
+          height: 0;
+          border-top: 60px solid #ea352d ;
+          border-right: 60px solid transparent;
+          border-bottom: 60px solid transparent;
+          border-left: 60px solid #ea352d ;
+          z-index: 100;
+          margin-left: 40px;
+          &__inner{
+            transform: rotate(-45deg);
+            font-size: 22px;
+            margin:-28px 0px 0px -55px;
+            color: #fff;
+            letter-spacing: 2px;
+            font-weight: 600;
+          }
+        }
         &__image{
           background-color: white;
           width: 220px;
@@ -337,11 +357,10 @@
             line-height: 1.5;
             font-size: 16px;
             text-align: left;
-          }
+            }
           .desc{
             font-size: 16px;
             display: flex;
-            align-items: center;
             justify-content: space-between;
               .price{
                 margin: 0;
@@ -352,7 +371,6 @@
                 padding: 0;
               }
             }
-          }
           .tax{
             font-size: 10px;
             text-align: left;
@@ -367,7 +385,7 @@
       }
     }
   }
-
+}
 
 .bottomBanner{
   background-image: image-url("material/pict/bg-appBanner-pict.jpg");
@@ -460,3 +478,4 @@
   font-size: 18px;
   margin-bottom: 5px;
 }
+

--- a/app/controllers/homes_controller.rb
+++ b/app/controllers/homes_controller.rb
@@ -1,6 +1,5 @@
 class HomesController < ApplicationController
   def index
     @item = Item.limit(3).order('created_at DESC')
-    @history = History.all
   end
 end

--- a/app/controllers/homes_controller.rb
+++ b/app/controllers/homes_controller.rb
@@ -1,4 +1,6 @@
 class HomesController < ApplicationController
   def index
+    @item = Item.limit(3).order('created_at DESC')
+    @history = History.all
   end
 end

--- a/app/controllers/homes_controller.rb
+++ b/app/controllers/homes_controller.rb
@@ -1,5 +1,5 @@
 class HomesController < ApplicationController
   def index
-    @item = Item.limit(3).order('created_at DESC')
+    @item = Item.limit(3).includes(:history, :item_images).order('created_at DESC')
   end
 end

--- a/app/views/homes/_main.html.haml
+++ b/app/views/homes/_main.html.haml
@@ -81,11 +81,10 @@
       .containerBox__lists
         - @item.each do |item|
           .containerBox-list
-            -@history.each do |history|
-              - if item.id == history.item_id
-                .containerBox-list__sold
-                  .containerBox-list__sold__inner
-                    SOLD
+            - if item.history
+              .containerBox-list__sold
+                .containerBox-list__sold__inner
+                  SOLD
           = link_to item_path(item.id), method: :get do
             .containerBox-list__image
               = image_tag item.item_images.first.image_URL.url,width: '220px',  class: 'img'

--- a/app/views/homes/_main.html.haml
+++ b/app/views/homes/_main.html.haml
@@ -79,39 +79,27 @@
     .containerBox
       .containerBox__headline 新規投稿商品
       .containerBox__lists
-        = link_to "#" do
+        - @item.each do |item|
           .containerBox-list
+            -@history.each do |history|
+              - if item.id == history.item_id
+                .containerBox-list__sold
+                  .containerBox-list__sold__inner
+                    SOLD
+          = link_to item_path(item.id), method: :get do
             .containerBox-list__image
-              = image_tag 'material/pict/a001.png', class: 'img'
+              = image_tag item.item_images.first.image_URL.url,width: '220px',  class: 'img'
             .containerBox-list__detail
-              %h3.name product1
+              %h3.name
+              =item.items_name
               %ul.desc
-                %li.price 30000円
+                %li.price
+                  = number_with_delimiter(item.price)
+                  円
                 %li.like
                   %i.fa.fa-star 0
-              %p.tax （税込み）
-        = link_to "#" do
-          .containerBox-list
-            .containerBox-list__image
-              = image_tag 'material/pict/a004.png', class: 'img'
-            .containerBox-list__detail
-              %h3.name product2
-              %ul.desc
-                %li.price 30000円
-                %li.like
-                  %i.fa.fa-star 0
-              %p.tax （税込み）
-        = link_to "#" do
-          .containerBox-list
-            .containerBox-list__image
-              = image_tag 'material/pict/a007.png', class: 'img'
-            .containerBox-list__detail
-              %h3.name product3
-              %ul.desc
-                %li.price 30000円
-                %li.like
-                  %i.fa.fa-star 0
-              %p.tax （税込み）
+              %p.tax（税込み）
+
 
 
   .bottomBanner


### PR DESCRIPTION
#WHAT
- トップページの商品一覧に出品された商品を表示する
- 商品が売り切れた場合はSOLDのマークが出る
# WHY
- 新しい商品が出品された事を明示し購入に結びつけるため
【動作プレビュー】
https://gyazo.com/38902bf6ac22a677d5f30ac3bb5c7418

- 商品が売り切れた際に購入されないようにするため
【動作プレビュー】
https://gyazo.com/118e28c43b90e30f41cf6b7c67d9c6fd
※購入された動作を再現するため手動でhistoryテーブルにデータを入力しています