### PR TITLE
priceに対するvalidation強化

### DIFF
--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -13,6 +13,6 @@ class Item < ApplicationRecord
 
   validates :items_name, :item_description, :condition, :shipping_costs, :days_to_ship, :price, :category_id, :shipping_area_id, presence: true
   validates :items_name, length: {maximum: 40}
-  validates :price, inclusion: { in: 300..9999999 }
+  validates :price, presence: true,numericality: {only_integer: true, greater_than_or_equal_to: 300, less_than_or_equal_to: 9999999}
 
 end

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -43,5 +43,20 @@ describe Item do
       item.valid?
       expect(item.errors[:shipping_costs]).to include("を入力してください")
     end
+    it "priceがinteger以外ならNG" do
+      item = build(:item, price: "３００")
+      item.valid?
+      expect(item.errors[:price]).to include("は数値で入力してください")
+    end
+    it "priceが300円未満ならNG" do
+      item = build(:item, price: "290")
+      item.valid?
+      expect(item.errors[:price]).to include("は300以上の値にしてください")
+    end
+    it "priceが9999999円よりも高額ならNG" do
+      item = build(:item, price: "19999999")
+      item.valid?
+      expect(item.errors[:price]).to include("は9999999以下の値にしてください")
+    end
   end
 end


### PR DESCRIPTION
# What
priceに対するValidationを強化しました。
```Ruby
inclusion{ in: 300...999999}
```
上記のコードから下記のコードに変更
```Ruby
numericality: {only_integer: true, greater_than_or_equal_to: 300, less_than_or_equal_to: 9999999}
```

# Why
後々バグが出ないようにするため。
より強いValidationでシステム強化を図る

# View
https://gyazo.com/c6f899df23abe38969deef58ac5a797f