### PR TITLE
出品ボタン条件分岐の修正

### DIFF
--- a/app/assets/stylesheets/modules/home/_index.scss
+++ b/app/assets/stylesheets/modules/home/_index.scss
@@ -463,7 +463,7 @@
   }
 
 
-.sellBtn{
+.sellBtn--login{
   width: 120px;
   height: 120px;
   background: #3CCACE;
@@ -479,3 +479,18 @@
   margin-bottom: 5px;
 }
 
+.sellBtn--logout{
+  width: 120px;
+  height: 120px;
+  background: #3CCACE;
+  text-align: center;
+  border-radius: 4%;
+  bottom: 32px;
+  right: 32px;
+  position: fixed;
+  padding: 10px;
+  color: #fff;
+  display: block;
+  font-size: 13px;
+  margin-bottom: 5px;
+}

--- a/app/views/homes/_sellBtn.html.haml
+++ b/app/views/homes/_sellBtn.html.haml
@@ -1,6 +1,15 @@
 
-= link_to new_item_path do
-  .sellBtn
-    出品する
-    .sellBtn--image
-    = image_tag 'material/icon/icon_camera.png',height: '54', width: '54', class: 'btn'
+- if user_signed_in?
+  = link_to new_item_path do
+    .sellBtn--login
+      出品する
+      .sellBtn--image
+      = image_tag 'material/icon/icon_camera.png',height: '54', width: '54', class: 'btn'
+
+- else
+  = link_to new_user_session_path do
+    .sellBtn--logout
+      ログインして
+      %br 出品
+      .sellBtn--image
+      = image_tag 'material/icon/icon_camera.png',height: '54', width: '54', class: 'btn'


### PR DESCRIPTION
# WHAT
出品ボタンの動作がすべて出品ページへのリンクになっていたため、ログインの有無でリンク先を変更するように修正しました。

【未ログイン】「ログインして出品」リンク先：ログインページ
【ログイン】「出品する」　リンク先：出品ページ

# WHY
未ログインのユーザーは出品できないため