### PR TITLE
商品詳細における動的写真表示

### DIFF
--- a/app/assets/javascripts/images_details.js
+++ b/app/assets/javascripts/images_details.js
@@ -1,0 +1,6 @@
+$(function(){
+  $(".smallbox").on('mouseover','img',function(){
+    let image = $(this).attr('src');
+    $(".bigPict").attr('src',image);
+  })
+})

--- a/app/assets/stylesheets/modules/item/_show_details.scss
+++ b/app/assets/stylesheets/modules/item/_show_details.scss
@@ -29,6 +29,9 @@
           }
         }
       }
+      p.explanation{
+        text-align: center;
+      }
       .price__box{
         text-align: center;
         margin-bottom: 24px;

--- a/app/assets/stylesheets/modules/item/_show_details.scss
+++ b/app/assets/stylesheets/modules/item/_show_details.scss
@@ -21,7 +21,7 @@
         margin: 10px;
         .bigbox{
           .bigPict{
-            object-fit: cover;
+            object-fit: contain;
           }
           .smallbox{
             display: flex;

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -24,7 +24,8 @@
                     = image_tag "#{item_image.image_URL}", height: '90', width: '140'
                   -else
                     = image_tag "#{item_image.image_URL}", height: '90', width: '140'
-      
+      %p.explanation
+        画像にカーソルを合わせると拡大されます
       .price__box
         %p.price
           ¥

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -8,14 +8,23 @@
       .image__box
         %ul.bigbox
           %li 
-            = image_tag 'material/pict/a001.png',  height: '330px', width: '100%',class: 'bigPict'
+            - @item.item_images.each.with_index do |item_image,i|
+              - if i==0
+                = image_tag "#{item_image.image_URL}",height: '330px', width: '600px',class: 'bigPict'
             %ul.smallbox
               %li
-                = image_tag 'material/pict/a004.png', height: '90', width: '140', class: "smallPict--first"
-              %li
-                = image_tag 'material/pict/a007.png', height: '90', width: '140',class: "smallPict--second"
-              %li
-                = image_tag 'material/pict/a001.png', height: '90', width: '140', class: "smallPict--third"
+                - @item.item_images.each.with_index do |item_image,i|
+                  -if i==0
+                    = image_tag "#{item_image.image_URL}", height: '90', width: '140'
+                  -elsif i==1
+                    = image_tag "#{item_image.image_URL}", height: '90', width: '140'
+                  -elsif i==2
+                    = image_tag "#{item_image.image_URL}", height: '90', width: '140'
+                  -elsif i==3
+                    = image_tag "#{item_image.image_URL}", height: '90', width: '140'
+                  -else
+                    = image_tag "#{item_image.image_URL}", height: '90', width: '140'
+      
       .price__box
         %p.price
           ¥
@@ -55,7 +64,7 @@
               = @item.days_to_ship
       - if user_signed_in? && current_user.id != @item.user_id
         .main__content__middle--buy
-          = link_to "購入画面に進む", "/transaction/buy/#{@item.id}",class:"button"
+          = link_to "購入画面に進む", buy_transaction_path(@item.id),class:"button"
         .main__content__middle--option
           %ul
             %li.favorite

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -14,16 +14,7 @@
             %ul.smallbox
               %li
                 - @item.item_images.each.with_index do |item_image,i|
-                  -if i==0
-                    = image_tag "#{item_image.image_URL}", height: '90', width: '140'
-                  -elsif i==1
-                    = image_tag "#{item_image.image_URL}", height: '90', width: '140'
-                  -elsif i==2
-                    = image_tag "#{item_image.image_URL}", height: '90', width: '140'
-                  -elsif i==3
-                    = image_tag "#{item_image.image_URL}", height: '90', width: '140'
-                  -else
-                    = image_tag "#{item_image.image_URL}", height: '90', width: '140'
+                  = image_tag "#{item_image.image_URL}", height: '90', width: '140'
       %p.explanation
         画像にカーソルを合わせると拡大されます
       .price__box


### PR DESCRIPTION
# What

- 写真表示を動的に実装しました。プレビューにカーソルを当てるとその画像が大スクリーンに映し出されるようにしました。

- メルカリの様にスライド式に動くものよりも操作が簡単だと思ったのでmouseoverで実装しました

# Why

- ユーザーが商品を買うときに写真を見やすくするため

- より操作を簡単にするため

# View 
https://gyazo.com/aad1ecddb95c4cda992d3d586752a2e1
