### PR TITLE
historyテーブルへの保存するコードを修正

### DIFF
--- a/app/controllers/transaction_controller.rb
+++ b/app/controllers/transaction_controller.rb
@@ -19,7 +19,7 @@ class TransactionController < ApplicationController
 
     # 先にhistoryテーブルへ保存。PayjpAPIがエラーを返してきたらロールバックする。
     History.transaction do 
-      History.create(user_id: current_user.id, id: @item.id)
+      History.create(user_id: current_user.id, item_id: @item.id)
       @result = Payjp::Charge.create(
         amount:   @item.price,
         customer: card.customer_id,


### PR DESCRIPTION
historyテーブルへの保存を行うコードにて、
カラム名の指定に誤りがあったため修正します。