### PR TITLE
商品詳細ページのカテゴリ表示実装

### DIFF
--- a/app/assets/stylesheets/modules/item/_show_details.scss
+++ b/app/assets/stylesheets/modules/item/_show_details.scss
@@ -62,6 +62,10 @@
               padding: 15px;
               width: 80%;
               border: 1px solid #dedede;
+              .categoryLink {
+                color:#3CCACE;
+                text-decoration:none;
+              }
             }
           }
         }

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -17,6 +17,7 @@ end
 
 def show
   @item = Item.find(params[:id])
+  @category = @item.category
 end
 
 

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -35,6 +35,14 @@
           %tr
             %th カテゴリ
             %td メンズ
+              = link_to root_path,class:"categoryLink" do
+                = @category.root.name
+                %br
+              = link_to root_path,class:"categoryLink" do
+                = @category.parent.name
+                %br
+              = link_to root_path,class:"categoryLink" do
+                = @category.name
           %tr
             %th ブランド
             %td 


### PR DESCRIPTION
#what
商品詳細ページに商品に登録されたカテゴリーの表示を実装しました。
リンク先が現在未設定ですが、今後同カテゴリー一覧にリンクする予定です。

#why
同じカテゴリの商品ごとにまとめる事で似たような商品が検索しやすくなる