### PR TITLE
配送先住所変更後のカード情報表示欄の不具合の修正

### DIFF
--- a/app/controllers/transaction_controller.rb
+++ b/app/controllers/transaction_controller.rb
@@ -5,7 +5,7 @@ class TransactionController < ApplicationController
   before_action :move_to_sold, only: [:buy, :pay]
   before_action :set_user_address, only: [:buy, :done, :address, :update_address]
   before_action :set_payjp_key, only: [:buy, :pay, :done, :card,:register_card]
-  before_action :set_card_info, only: [:buy, :done, :card]
+  before_action :set_card_info, only: [:buy, :done, :card, :update_address]
 
   # 購入確認画面
   def buy


### PR DESCRIPTION
購入確認画面にて、配送先住所画面に遷移して住所変更を行った後に、
購入画面に戻った際、クレジットカードが登録済みの状態にもかかわらず、
カード未登録状態扱いの表示になってしまう不具合を修正します。