### PR TITLE
編集画面へのパス指定

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -29,6 +29,10 @@ class ItemsController < ApplicationController
 
   # 出品商品編集用
   def edit
+    if @item.user_id != current_user.id
+      redirect_to root_path
+    end
+
     grandchild_category = @item.category
     child_category = grandchild_category.parent
 

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -79,7 +79,7 @@
                 不適切な商品の通報
       - elsif user_signed_in? && current_user.id == @item.user_id
         .main__content__middle--edit
-          = link_to "編集する","#",class:"edit-btn"
+          = link_to "編集する", edit_item_path(@item), class:"edit-btn"
         .main__content__middle--delete
           = link_to "削除する","#",class:"delete-btn"
       - else 


### PR DESCRIPTION
# What
- 商品詳細画面の編集ボタンから編集画面に遷移するようにパス指定
- 出品したユーザ以外が商品編集画面を開こうとするとrootにリダイレクトするように実装

# Why
- 商品詳細ページからも編集画面に遷移し編集できるようにするため
- 出品したユーザ以外が商品情報を編集できないようにするため