### PR TITLE
商品削除機能実装

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,7 +1,7 @@
 class ItemsController < ApplicationController
 
   before_action :move_to_login
-  before_action :set_item, only: [:show, :edit, :update]
+  before_action :set_item, only: [:show, :edit, :update, :destroy]
 
   # 出品した商品一覧表示用
   def index
@@ -62,6 +62,20 @@ class ItemsController < ApplicationController
       end
     else
       redirect_back(fallback_location: root_path)
+    end
+  end
+
+  # 商品削除用
+  def destroy
+    if @item.user.id == current_user.id
+      if @item.destroy
+        redirect_to update_complete_user_path(current_user.id), notice: "商品を削除しました"
+      else
+        redirect_to update_complete_user_path(current_user.id), alert: '削除に失敗しました'
+      end
+    else
+      flash.now[:error] = '削除できません'
+      render update_complete_user_path(current_user.id)
     end
   end
 

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -8,7 +8,7 @@ class Item < ApplicationRecord
   belongs_to :category
   belongs_to :brand, optional: true
   belongs_to :user  
-  has_one    :rating, dependent: :destroy
+  has_one    :rating
   has_one    :history
 
   validates :items_name, :item_description, :condition, :shipping_costs, :days_to_ship, :price, :category_id, :prefecture_id, presence: true

--- a/app/views/items/index.html.haml
+++ b/app/views/items/index.html.haml
@@ -19,5 +19,6 @@
                     = link_to edit_item_path(item) do
                       編集
                   %li.ex-items__index__item__btn__delete
-                
+                    = link_to item_path(item), method: :delete, data: { confirm: "削除しますか？" } do
+                      削除
 = render 'homes/footerMain'

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -81,7 +81,7 @@
         .main__content__middle--edit
           = link_to "編集する","#",class:"edit-btn"
         .main__content__middle--delete
-          = link_to "削除する","#",class:"delete-btn"
+          = link_to "削除する", item_path(@item), method: :delete, data: { confirm: "削除しますか？" }, class: "delete-btn"
       - else 
         .main__content__middle--login
           = link_to "ログインする","/users/sign_in",class:"login-btn"


### PR DESCRIPTION
## What
- 出品商品削除機能実装
destroyアクション追加
商品出品者のみが削除できる
削除する前に確認ポップアップが出る
ratingの dependent: :destroyオプション削除（rating実装していないため）

## Why
ユーザーが出品した商品を取り消したい場合、削除出来るようにする為

削除動き↓
https://gyazo.com/e030b3ef1c57f4241d4762b165aa30c6