### PR TITLE
売却済みの商品は編集と削除ができないようにする

### DIFF
--- a/app/assets/stylesheets/modules/item/_show_details.scss
+++ b/app/assets/stylesheets/modules/item/_show_details.scss
@@ -125,6 +125,14 @@
         color: gray;
       }
     }
+    &--sold{
+      .sold-btn{
+        background: gray;     
+        color: white;     
+        @include btn-style();
+        cursor: auto;
+      }
+    }
     &--login{
       .login-btn{
         background-color: #EA352D;

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -2,6 +2,7 @@ class ItemsController < ApplicationController
 
   before_action :move_to_login
   before_action :set_item, only: [:show, :edit, :update, :destroy]
+  before_action :item_purchased?, only: [:edit, :update, :destroy]
 
   # 出品した商品一覧表示用
   def index
@@ -62,7 +63,7 @@ class ItemsController < ApplicationController
         redirect_to update_complete_user_path(current_user.id), notice: "商品を更新しました"
       else
         flash.now[:error] = '更新失敗'
-        render update_complete_user_path
+        render 'users/update_complete' 
       end
     else
       redirect_back(fallback_location: root_path)
@@ -79,7 +80,7 @@ class ItemsController < ApplicationController
       end
     else
       flash.now[:error] = '削除できません'
-      render update_complete_user_path(current_user.id)
+      render 'users/update_complete'
     end
   end
 
@@ -111,6 +112,13 @@ class ItemsController < ApplicationController
 
   def move_to_login
     redirect_to new_user_session_path unless user_signed_in?
+  end
+
+  def item_purchased?
+    if @item.history.present?
+      flash.now[:error] = '購入済みの商品の編集/削除はできません'
+      render 'users/update_complete' 
+    end
   end
 
 end

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -78,10 +78,15 @@
               %span
                 不適切な商品の通報
       - elsif user_signed_in? && current_user.id == @item.user_id
-        .main__content__middle--edit
-          = link_to "編集する", edit_item_path(@item), class:"edit-btn"
-        .main__content__middle--delete
-          = link_to "削除する", item_path(@item), method: :delete, data: { confirm: "削除しますか？" }, class: "delete-btn"
+        - if @item.history.blank?
+          .main__content__middle--edit
+            = link_to "編集する", edit_item_path(@item), class:"edit-btn"
+          .main__content__middle--delete
+            = link_to "削除する", item_path(@item), method: :delete, data: { confirm: "削除しますか？" }, class: "delete-btn"
+        - else 
+          .main__content__middle--sold
+            .sold-btn
+              売り切れ
       - else 
         .main__content__middle--login
           = link_to "ログインする","/users/sign_in",class:"login-btn"


### PR DESCRIPTION
# what
売り切れた商品の編集/削除は行えないようにします。
詳細には以下の対応を行います。
- view側で編集/削除ページへのリンクを塞ぐ
- controller側でedit/udpate/destroyアクションを行う前に売り切れかどうかチェックし、売り切れならそれを知らせる画面に遷移させる

また、作業対象のコントローラにて、他コントローラのビューに対してrenderメソッドを使用していたことによりエラーが発生するコードがあったため、これの修正も行います。

# why
本アプリケーションでは、商品が購入された時に、購入履歴と共に商品情報を全て保存するようには設計されておらず、
購入者が購入した商品を確認した際に、情報が変わるのを防ぐため。