### PR TITLE
マイページ出品商品一覧表示実装

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -29,6 +29,7 @@
 @import "modules/item/edit_image_form";
 @import "mixin/show_details_mixin";
 @import "modules/item/show_details";
+@import "modules/item/index";
 
 @import "mixin/single_box";
 @import "modules/card/register_card";

--- a/app/assets/stylesheets/mixin/item_form_mixin.scss
+++ b/app/assets/stylesheets/mixin/item_form_mixin.scss
@@ -33,3 +33,18 @@
 border-bottom: 1px solid;
 border-color: #eeeeee;
 }
+
+@mixin small_btn_style {
+  margin: 0 10px;
+  a {
+    padding: 10px;
+    border-radius: 5px;
+    color: #777777;
+    background-color: #eeeeee;
+    border: 1px solid #dddddd;
+  }
+  a:hover {
+    color: #333333;
+    border: 1px solid #aaaaaa;
+  }
+}

--- a/app/assets/stylesheets/modules/item/_index.scss
+++ b/app/assets/stylesheets/modules/item/_index.scss
@@ -1,0 +1,45 @@
+.ex-items {
+  &__title {
+    @include user_title;
+  }
+  &__box {
+    padding: 10px;
+    .show {
+      display: inline;
+    }
+    &__index {
+      display: none;
+      &__item {
+        margin: 10px;
+        height: 70px;
+        display: flex;
+        border-bottom: 1px solid #cccccc;
+        line-height: 70px;
+        &__img {
+          margin: 2px 8px;
+          height: 62px;
+          width: 62px;
+          img {
+            border-radius: 50%;
+          }
+        }
+        &__name {
+          margin-left: 20px;
+          font-size: 20px;
+        }
+        &__btn {
+          margin: 0 0 0 auto;
+          padding-right: 30px;
+          display: flex;
+          line-height: 70px;
+          &__edit {
+            @include small_btn_style;
+          }
+          &__delete {
+            @include small_btn_style;
+          }
+        }
+      }
+    }
+  }
+}

--- a/app/assets/stylesheets/modules/user/_mypage_main.scss
+++ b/app/assets/stylesheets/modules/user/_mypage_main.scss
@@ -8,14 +8,24 @@
     }
     &__profileBox {
       padding: 20px 0 50px 0;
-      &__profile--img {
-        margin: auto;
-        height: 100px;
-        width: 100px;
-        border-radius: 50px;
-        line-height: 100px;
-        background-color: #3CCACE;
-        color: white;
+      &__profile {
+        &--img {
+          margin: auto;
+          height: 100px;
+          width: 100px;
+          img {
+            border-radius: 50%;
+          }
+        }
+        &--dummy {
+          margin: auto;
+          height: 100px;
+          width: 100px;
+          border-radius: 50px;
+          line-height: 100px;
+          background-color: #3CCACE;
+          color: white;
+        }
       }
       &__info {
         text-align: center;

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -7,7 +7,7 @@ class ItemsController < ApplicationController
   def index
     @items = current_user.items.order('created_at DESC')
   end
-    
+
   def new
     @item = Item.new
     @item.item_images.new

--- a/app/views/items/index.html.haml
+++ b/app/views/items/index.html.haml
@@ -7,18 +7,26 @@
       .mypage__main__top
         .ex-items
           .ex-items__title
-            出品した商品
-          .ex-items__index
-            - @items.each do |item|
-              .ex-items__index__item
-                .ex-items__index__item__img
-                .ex-items__index__item__name
-                  = item.items_name
-                %ul.ex-items__index__item__btn
-                  %li.ex-items__index__item__btn__edit
-                    = link_to edit_item_path(item) do
-                      編集
-                  %li.ex-items__index__item__btn__delete
-                    = link_to item_path(item), method: :delete, data: { confirm: "削除しますか？" } do
-                      削除
+            出品商品
+          .ex-items__box
+            .ex-items__box__index.show
+              - @items.each do |item|
+                .ex-items__box__index__item
+                  .ex-items__box__index__item__img
+                    = image_tag item.item_images.first.image_URL.url, width: '62px', height: '62px'
+                  .ex-items__box__index__item__name
+                    = item.items_name
+                  .ex-items__box__index__item__sold
+                    - if item.history
+                      【売却済み】
+                  .ex-items__box__index__item__btn
+                  - if item.history
+                    .ex-items__box__index__item__btn__delete
+                      = link_to "削除", item_path(item), method: :delete, data: { confirm: "削除しますか？" }
+                  - else
+                    .ex-items__box__index__item__btn__edit
+                      = link_to "編集", edit_item_path(item)
+                    .ex-items__box__index__item__btn__delete
+                      = link_to "削除", item_path(item), method: :delete, data: { confirm: "削除しますか？" }
+
 = render 'homes/footerMain'

--- a/app/views/users/_mypage_main.html.haml
+++ b/app/views/users/_mypage_main.html.haml
@@ -3,14 +3,19 @@
     .mypage__main__top__title
       #{current_user.nickname}さんのマイページ
     .mypage__main__top__profileBox
-      .mypage__main__top__profileBox__profile--img
-        イメージ画像
+      .mypage__main__top__profileBox__profile
+        - if @user.profile_image.present?
+          .mypage__main__top__profileBox__profile--img
+            = image_tag @user.profile_image.url, size: "100x100"
+        - else
+          .mypage__main__top__profileBox__profile--dummy
+            イメージ画像
       .mypage__main__top__profileBox__info
         .mypage__main__top__profileBox__info__top
           .mypage__main__top__profileBox__info__top__rate
             評価：０
           .mypage__main__top__profileBox__info__top__items
-            出品数：０
+            出品数：#{current_user.items.count}
         .mypage__main__top__profileBox__info__profit
           今までの利益：¥0
   .mypage__main__container

--- a/app/views/users/_mypage_sidebar.html.haml
+++ b/app/views/users/_mypage_sidebar.html.haml
@@ -13,7 +13,7 @@
     %h4.mypage__sidebar__box__title 商品
     %ul.mypage__sidebar__box__list
       %li.mypage__sidebar__box__list__item#sale
-        = link_to "#" do
+        = link_to new_item_path do
           出品する
           = icon('fa', 'chevron-right')
       %li.mypage__sidebar__box__list__item#saleItem


### PR DESCRIPTION
## What
出品した商品をリスト形式で表示
売却済みのものは編集できないように表示
＜微調整＞
サイドバーの出品するのlink先追記
マイページイメージ画像表示
マイページ出品数表示
## Why
自分で出品した商品が一覧で見れるようにする為

## キャプチャ
出品商品一覧
https://gyazo.com/120af5afc74927851c20553540e7317e

マイページ
https://gyazo.com/a87df61a1d50b02cef1362b7163a01ea