### PR TITLE
商品詳細画面にて、売り切れボタンを表示する条件処理の修正

### DIFF
--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -62,7 +62,11 @@
             %th 発送日の目安
             %td 
               = @item.days_to_ship
-      - if user_signed_in? && current_user.id != @item.user_id
+      - if @item.history.present?
+        .main__content__middle--sold
+          .sold-btn
+            売り切れ
+      - elsif user_signed_in? && current_user.id != @item.user_id
         .main__content__middle--buy
           = link_to "購入画面に進む", buy_transaction_path(@item.id),class:"button"
         .main__content__middle--option
@@ -78,15 +82,10 @@
               %span
                 不適切な商品の通報
       - elsif user_signed_in? && current_user.id == @item.user_id
-        - if @item.history.blank?
-          .main__content__middle--edit
-            = link_to "編集する", edit_item_path(@item), class:"edit-btn"
-          .main__content__middle--delete
-            = link_to "削除する", item_path(@item), method: :delete, data: { confirm: "削除しますか？" }, class: "delete-btn"
-        - else 
-          .main__content__middle--sold
-            .sold-btn
-              売り切れ
+        .main__content__middle--edit
+          = link_to "編集する", edit_item_path(@item), class:"edit-btn"
+        .main__content__middle--delete
+          = link_to "削除する", item_path(@item), method: :delete, data: { confirm: "削除しますか？" }, class: "delete-btn"
       - else 
         .main__content__middle--login
           = link_to "ログインする","/users/sign_in",class:"login-btn"


### PR DESCRIPTION
# what
商品詳細画面にて、現状の実装だと「売り切れ」ボタンが表示されるのはその商品を出品したユーザーのみであったため、出品者以外のユーザーでも、売り切れ済み商品の詳細画面に遷移した際は、「売り切れ」ボタンが表示されるように、app/views/items/show.html.haml内の条件分岐処理の修正を行います。

# why
ユーザーが売り切れた商品の購入詳細画面に遷移するのを阻止するため。