### PR TITLE
itemsコントローラのindex/editアクションにおいても、@parentsを定義するように修正

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,6 @@
 class ItemsController < ApplicationController
 
-  before_action :set_parents, only:[:index, :show]
+  before_action :set_parents, only: [:index, :show, :edit]
   before_action :move_to_login
   before_action :set_item, only: [:show, :edit, :update, :destroy]
   before_action :item_purchased?, only: [:edit, :update, :destroy]

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,6 @@
 class ItemsController < ApplicationController
 
-  before_action :set_parents, only:[:show]
+  before_action :set_parents, only:[:index, :show]
   before_action :move_to_login
   before_action :set_item, only: [:show, :edit, :update, :destroy]
   before_action :item_purchased?, only: [:edit, :update, :destroy]


### PR DESCRIPTION
出品した商品一覧を表示する際及び、
商品の編集画面を表示する際にエラーが発生しており、
これの修正を行うために、
itemsコントローラにて@parentsを定義しているbefore_actionに、index actionを含めます。