### PR TITLE
マイページ画面トップのビューの修正

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -10,6 +10,10 @@ class UsersController < ApplicationController
   # マイページメイン画面用
   def show
     @bought_items = current_user.bought_item
+    @sales = 0
+    current_user.items.each do |item|
+      @sales += item.price if item.history.present?
+    end
   end
 
   # マイページからのログアウト用

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -12,7 +12,7 @@ class UsersController < ApplicationController
     @bought_items = current_user.bought_item
     @sales = 0
     current_user.items.each do |item|
-      @sales += item.price if item.history.present?
+      @sales += (item.price * 0.9).round if item.history.present?
     end
   end
 

--- a/app/views/users/_mypage_main.html.haml
+++ b/app/views/users/_mypage_main.html.haml
@@ -12,12 +12,10 @@
             イメージ画像
       .mypage__main__top__profileBox__info
         .mypage__main__top__profileBox__info__top
-          .mypage__main__top__profileBox__info__top__rate
-            評価：０
           .mypage__main__top__profileBox__info__top__items
             出品数：#{current_user.items.count}
         .mypage__main__top__profileBox__info__profit
-          今までの利益：¥0
+          = "今までの利益：¥#{@sales}"
   .mypage__main__container
     %ul.mypage__main__container__menu
       %li.mypage__main__container__menu__title#favorite.active
@@ -28,20 +26,6 @@
         出品商品
     %ul.mypage__main__container__itemBox
       %li.mypage__main__container__itemBox__list.show
-        .mypage__main__container__itemBox__list__item
-          favoriteItem
-        .mypage__main__container__itemBox__list__item
-          favoriteItem
-        .mypage__main__container__itemBox__list__item
-          favoriteItem
-        .mypage__main__container__itemBox__list__item
-          favoriteItem
-        .mypage__main__container__itemBox__list__item
-          favoriteItem
-        .mypage__main__container__itemBox__list__item
-          favoriteItem
-        .mypage__main__container__itemBox__list__item
-          favoriteItem
       %li.mypage__main__container__itemBox__list
         - @bought_items.each do |item|
           .mypage__main__container__itemBox__list__item
@@ -54,5 +38,13 @@
                 = number_with_delimiter(item.price)
                 円（税込み）
       %li.mypage__main__container__itemBox__list
-        .mypage__main__container__itemBox__list__item
-          saleItem
+        - current_user.items.each do |item|
+          .mypage__main__container__itemBox__list__item
+            = link_to item_path(item.id), method: :get do
+              .item-image
+                = image_tag item.item_images.first.image_URL.url, width: '178px', class: 'img'
+              .item-name
+                = item.items_name
+              .item-price
+                = number_with_delimiter(item.price)
+                円（税込み）

--- a/app/views/users/_mypage_main.html.haml
+++ b/app/views/users/_mypage_main.html.haml
@@ -48,3 +48,5 @@
               .item-price
                 = number_with_delimiter(item.price)
                 円（税込み）
+                - if item.history.present?
+                  %br 【売却済み】


### PR DESCRIPTION
# what
マイページトップにて、以下修正を行います。
- 総売上金額を表示
- 評価を削除
- お気に入り商品一覧部分のダミー表示を削除
- 出品商品タブ内に出品した商品を表示する

# why
見栄えを良くするため。
商品出品状況/購入状況/売り上げを視認できるようにするため。