### PR TITLE
マイページサイドバーからの購入商品一覧表示（リスト表示）

### DIFF
--- a/app/assets/stylesheets/modules/item/_index.scss
+++ b/app/assets/stylesheets/modules/item/_index.scss
@@ -38,6 +38,9 @@
           &__delete {
             @include small_btn_style;
           }
+          &__show {
+            @include small_btn_style;
+          }
         }
       }
     }

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,6 +1,6 @@
 class ItemsController < ApplicationController
 
-  before_action :set_parents, only:[:show]
+  before_action :set_parents, only:[:show, :index, :buyitem]
   before_action :move_to_login
   before_action :set_item, only: [:show, :edit, :update, :destroy]
   before_action :item_purchased?, only: [:edit, :update, :destroy]
@@ -8,6 +8,10 @@ class ItemsController < ApplicationController
   # 出品した商品一覧表示用
   def index
     @items = current_user.items.order('created_at DESC')
+  end
+
+  def buyitem
+    @bought_items = current_user.bought_item
   end
 
   def new

--- a/app/views/items/buyitem.html.haml
+++ b/app/views/items/buyitem.html.haml
@@ -1,0 +1,23 @@
+= render 'homes/headerMain'
+.mainbox
+  .mypage
+    = render "users/mypage_sidebar"
+
+    .mypage__main
+      .mypage__main__top
+        .ex-items
+          .ex-items__title
+            購入商品
+          .ex-items__box
+            .ex-items__box__index.show
+              - @bought_items.each do |item|
+                .ex-items__box__index__item
+                  .ex-items__box__index__item__img
+                    = image_tag item.item_images.first.image_URL.url, width: '62px', height: '62px'
+                  .ex-items__box__index__item__name
+                    = item.items_name
+                  .ex-items__box__index__item__btn
+                    .ex-items__box__index__item__btn__show
+                      = link_to "詳細", item_path(item.id), method: :get
+
+= render 'homes/footerMain'

--- a/app/views/users/_mypage_sidebar.html.haml
+++ b/app/views/users/_mypage_sidebar.html.haml
@@ -21,7 +21,7 @@
           出品した商品
           = icon('fa', 'chevron-right')
       %li.mypage__sidebar__box__list__item#buyItem
-        = link_to "#" do
+        = link_to buyitem_items_path do
           購入した商品
           = icon('fa', 'chevron-right')
       %li.mypage__sidebar__box__list__item#favoriteItem

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -26,6 +26,7 @@ Rails.application.routes.draw do
 
   resources :items  do
     collection do
+      get 'buyitem'
       get 'get_category_children', defaults: {format: 'json'}
       get 'get_category_grandchildren', defaults: {format: 'json'}
     end


### PR DESCRIPTION
## What
マイページのサイドバーから遷移する購入商品一覧表示の実装

## Why
出品商品と同様に購入商品も一覧表示で見れるようにする為

## View
https://gyazo.com/332eadb6c27fe81d0cc6051f8f3a466c